### PR TITLE
Removed 1 unnecessary stubbing in AbstractArtifactTest.java

### DIFF
--- a/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/SecondAbstractArtifactTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/SecondAbstractArtifactTest.java
@@ -1,0 +1,72 @@
+package org.jvnet.hudson.plugins.repositoryconnector;
+
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+import java.nio.file.Files;
+
+import org.junit.After;
+import org.junit.Before;
+import org.jvnet.hudson.plugins.repositoryconnector.aether.Aether;
+import org.jvnet.hudson.plugins.repositoryconnector.util.TokenMacroExpander;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import hudson.FilePath;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+
+abstract class SecondAbstractArtifactTest {
+
+    protected List<Artifact> artifacts;
+
+    @Mock
+    protected Aether mockAether;
+
+    @Mock
+    protected TokenMacroExpander mockExpander;
+
+    @Mock
+    protected TaskListener mockListener;
+
+    @Mock
+    protected PrintStream mockPrintStream;
+
+    @Mock
+    protected Run<?, ?> mockRun;
+
+    protected FilePath workspace;
+
+    @After
+    public void after() throws Exception {
+        workspace.deleteRecursive();
+    }
+
+    @Before
+    public void before() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        
+        artifacts = new ArrayList<>();
+        workspace = new FilePath(Files.createTempDirectory(null).toFile());
+    }
+
+    protected File getTestJar() throws URISyntaxException {
+        return new File(this.getClass().getResource("test.jar").toURI());
+    }
+
+    @SuppressWarnings("unused")
+    protected Artifact createArtifact(boolean failOnError) throws Exception {
+        Artifact artifact = new Artifact("org.junit.jupiter", "junit-jupiter", "5.7.0");
+        artifact.setFailOnError(failOnError);
+
+        artifacts.add(artifact);
+        when(mockExpander.expand(artifact)).thenReturn(artifact);
+
+        return artifact;
+    }
+}

--- a/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinitionTest.java
+++ b/src/test/java/org/jvnet/hudson/plugins/repositoryconnector/VersionParameterDefinitionTest.java
@@ -15,7 +15,7 @@ import org.mockito.Mock;
 
 import hudson.model.Item;
 
-public class VersionParameterDefinitionTest extends AbstractArtifactTest {
+public class VersionParameterDefinitionTest extends SecondAbstractArtifactTest {
 
     @Mock
     private Item mockItem;


### PR DESCRIPTION
In our analysis of the project, we observed that 
1) the stubbing in the `AbstractArtifactTest.before` is created but never executed by 3 tests: `VersionParameterDefinitionTest.testGetVersions`, `VersionParameterDefinitionTest.testGetVersionParameterValue`, and `VersionParameterDefinitionTest.testEscapeInputs`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html).

We propose below a solution to remove the unnecessary stubbing.